### PR TITLE
Retitle oldest commit as oldest merge

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
       <th class="commits">commits</th>
       <th class="merges">merges</th>
       <th class="name">application</th>
-      <th class="last-deploy">oldest commit</th>
+      <th class="last-deploy">oldest merge</th>
     </tr>
   </thead>
 </table>


### PR DESCRIPTION
Commit e3bef0d updated the timestamp to show the age of the oldest merge rather than the oldest commit. This updates the title to match.
