### PR TITLE
Build compare url with tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Pass configuration as query params, supported params are;
 * `refresh` - How often to update, in seconds [_optional_, defaults to `60`]
 * `from` - A treeish (tag, branch, etc) to start comparing from
 * `to` - A treeish (tag, branch, etc) to compare until [_optional_, defaults to `master`]
+* `resolve_tags` - Set this to anything truthy (ie not an empty string) to look up tags for the `from` and `to` commits to use in the title compare link [_optional_, defaults to off]
 
 ## To do
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -48,6 +48,7 @@ $(document).ready(function() {
   var to_tag = getQueryVariable('to') || 'master';
   var api_token = getQueryVariable('token');
   var repo_owner = getQueryVariable('owner') || 'alphagov';
+  var resolve_tags = !!getQueryVariable('resolve_tags');
 
   var repos_container = $('#repos');
 
@@ -147,7 +148,7 @@ $(document).ready(function() {
     // Reset the compare URL to use original references
     repo.http_compare_url = build_http_compare_url(repo.path, from_tag, to_tag);
 
-    if (repo.commits_ahead) {
+    if (resolve_tags && repo.commits_ahead) {
       repo.oldest_sha = repo_state.base_commit.sha;
       repo.newest_sha = repo_state.commits[repo_state.commits.length - 1].sha;
 


### PR DESCRIPTION
Build the compare URL (which is used as the href for the repo title anchor) using tags.

In our workflow tags are stable, whereas the tracked branches keep moving. Having compare URLs which use stable tags means we can use them as release candidates without having to manually lookup the release number tags for the start and end commits.

If tags can't be found for the commits it just falls back to the tracked branches.

The functionality is hidden behind a query parameter – stick `resolve_tags=yep` or any other value you feel like onto the URL to see it.
