### PR TITLE
Hide up-to-date repos from the list

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -54,9 +54,8 @@ table td.merges {
   text-align: center;
 }
 
-table tr.good td.commits,
-table tr.good td.merges {
-  color: green;
+table tr.good {
+  display: none;
 }
 
 table tr.stale td.commits,


### PR DESCRIPTION
- We have a lot of repos to care about - the list of the stale ones is
  generally plenty long enough.
- It is worth noting that some teams might like to see up-to-date repos, and this change will break that. Maybe we could make it like 4th Wall and use custom CSS?

Paired with @evilstreak on this.