### PR TITLE
Interface tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It's intended to highlight changes that may sit undeployed for a long time, caus
 
 Pass configuration as query params, supported params are;
 
-* `token` - A Github API token
+* `token` - A Github API token. You can get one by [creating a personal access token](https://github.com/settings/tokens/new) with the `public_repo` scope.
 * `repos` - A comma-seperated list of repository names on [@alphagov](https://github.com/alphagov)
 * `refresh` - How often to update, in seconds [_optional_, defaults to `60`]
 * `from` - A treeish (tag, branch, etc) to start comparing from

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3,14 +3,15 @@ body {
   padding: 0;
 
   font: small/1.4 sans-serif;
-  color: #222;
-  background: #fff
+  color: #fff;
+  font-family: ntatabularnumbers, nta, sans-serif;
+  background:black;
 }
 
 h1 {
   margin: 0;
   font-size: 2em;
-  background: dodgerBlue;
+  background: #2E8ACA;
   color: #fff;
   padding: 10px 30px;
   font-weight: normal;
@@ -18,6 +19,7 @@ h1 {
 
 table {
   width: 100%;
+  border-collapse: collapse;
 }
 
 table th,
@@ -27,24 +29,24 @@ table td {
 
 table th {
   text-align: left;
-  color: #ccc;
+  color: #6F777B;
   font-weight: normal;
   font-size: 2em;
 }
 
 table td {
-  font-size: 3em;
-  border-bottom: 1px solid #ccc;
+  font-size: 2.5em;
+  border-bottom: 1px solid #6F777B;
 }
 
 table td.name a {
   text-decoration: none;
-  color: #222;
+  color: #fff;
 }
 
 table td.time {
   font-size: 2em;
-  color: #888;
+  color: #6F777B;
 }
 
 table th.commits,
@@ -64,9 +66,8 @@ table tr.unknown td.merges {
 }
 
 table tr.very-stale td.time {
-  color: red;
+  color: #B10E1E;
 }
-
 
 body.april-fools {
   transform: scaleX(-1);

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -8,6 +8,14 @@ body {
   background:black;
 }
 
+.commits, h1, thead {
+  display: none;
+}
+
+table {
+  margin-top: 20px;
+}
+
 h1 {
   margin: 0;
   font-size: 2em;
@@ -56,6 +64,16 @@ table th.merges,
 table td.commits,
 table td.merges {
   text-align: center;
+}
+
+table td.merges {
+  text-align: left;
+}
+
+table td.merges small {
+  font-size: 18px;
+  color: #CCC;
+  vertical-align: middle;
 }
 
 table tr.unknown td.commits,

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -25,6 +25,7 @@ table {
 table th,
 table td {
   padding: 20px 30px;
+  border-bottom: 10px solid #000;
 }
 
 table th {
@@ -36,7 +37,6 @@ table th {
 
 table td {
   font-size: 2.5em;
-  border-bottom: 1px solid #6F777B;
 }
 
 table td.name a {
@@ -68,7 +68,8 @@ table tr.unknown td.merges {
 }
 
 table tr.very-stale td.time {
-  color: #B10E1E;
+  color: #fff;
+  background-color: #BF1E2D;
 }
 
 body.april-fools {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -42,6 +42,7 @@ table td {
 table td.name a {
   text-decoration: none;
   color: #fff;
+  font-weight: bold;
 }
 
 table td.time {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -58,13 +58,14 @@ table td.merges {
   text-align: center;
 }
 
-table tr.good {
-  display: none;
-}
-
 table tr.unknown td.commits,
 table tr.unknown td.merges {
   color: orange;
+}
+
+table tr.good td.time {
+  color: #fff;
+  background-color: green;
 }
 
 table tr.very-stale td.time {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -43,6 +43,7 @@ table td.name a {
   text-decoration: none;
   color: #fff;
   font-weight: bold;
+  white-space: nowrap;
 }
 
 table td.time {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -24,7 +24,7 @@ table {
 
 table th,
 table td {
-  padding: 20px 30px;
+  padding: 5px 30px;
   border-bottom: 10px solid #000;
 }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -193,9 +193,16 @@ $(document).ready(function() {
   }
 
   function redraw_repo(repo) {
+    if (repo.merges_ahead) {
+      var message = repo.merges_ahead == 1 ? 'undeployed pull request' : 'undeployed pull requests';
+      var merges_text = repo.merges_ahead + ' <small>' + message + '</small>';
+    } else {
+      var merges_text = '✔';
+    }
+
     repo.$el.find('.commits').text(repo.commits_ahead || '✔');
     repo.$el.attr('class', repo_state(repo));
-    repo.$el.find('.merges').text(repo.merges_ahead || '✔');
+    repo.$el.find('.merges').html(merges_text);
     repo.$el.find('.name a').attr('href', repo.http_compare_url);
     repo.$el.find('.time').text(repo.oldest_merge ? prettyDate(repo.oldest_merge) : 'all deployed');
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -197,10 +197,10 @@ $(document).ready(function() {
     repo.$el.attr('class', repo_state(repo));
     repo.$el.find('.merges').text(repo.merges_ahead || '✔');
     repo.$el.find('.name a').attr('href', repo.http_compare_url);
-    repo.$el.find('.time').text(repo.oldest_merge ? prettyDate(repo.oldest_merge) : '');
- 
+    repo.$el.find('.time').text(repo.oldest_merge ? prettyDate(repo.oldest_merge) : 'all deployed');
+
     // TODO: Don't resort the entire list when a single repo updates.
-    sort_repos(); 
+    sort_repos();
   }
 
   function sort_repos() {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -32,9 +32,7 @@ function prettyDate(time){
       diff < 7200 && "1 hour ago" ||
       diff < 86400 && Math.floor( diff / 3600 ) + " hours ago") ||
     day_diff == 1 && "Yesterday" ||
-    day_diff < 7 && day_diff + " days ago" ||
-    day_diff < 31 && Math.ceil( day_diff / 7 ) + " weeks ago" ||
-    day_diff < 365 && Math.ceil( day_diff / 31 ) + " months ago" ||
+    day_diff < 365 && day_diff + " days ago" ||
     '1 Year+';
 }
 

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <title>Deploy Lag Radiator</title>
+  <link rel="stylesheet" href="https://assets.digital.cabinet-office.gov.uk/static/fonts.css">
   <link rel="stylesheet" type="text/css" href="assets/css/main.css">
   <meta http-equiv="refresh" content="21600">
 </head>


### PR DESCRIPTION
Hi!

Our monitor over at Finding Things has been running this fork for a while now, and people seem okay with it. So I thought it might be time to discuss merging this back in.

Screenshot:

![photo 02-10-2015 16 38 25](https://cloud.githubusercontent.com/assets/233676/10250674/31d2b69e-6924-11e5-9f82-ad39f738eb34.jpg)

Zoomed:

![screen shot 2015-10-02 at 16 44 46](https://cloud.githubusercontent.com/assets/233676/10250805/ee10f0a0-6924-11e5-8ccd-41f6e79fc46c.png)

I've tried to let it fit in more with the fourth-wall (which we have next to this one) and make it more focussed by removing the number of commits a repo is behind and only displaying the number of pull requests. More info in individual commits.

There's some cleanup to do after https://github.com/dsingleton/deploy-lag-radiator/commit/f64c2cfea1265462131cf80cf31e8964efbd219d, but I wanted to wait for feedback.